### PR TITLE
Add migrations to work better with Django 1.8

### DIFF
--- a/registration/__init__.py
+++ b/registration/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 1, 0, 'rc', 1)
+VERSION = (1, 1, 0, 'rc', 2)
 
 
 def get_version():

--- a/registration/migrations/0001_initial.py
+++ b/registration/migrations/0001_initial.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RegistrationProfile',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('activation_key', models.CharField(max_length=40, verbose_name='activation key')),
+                ('user', models.OneToOneField(verbose_name='user', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'verbose_name': 'registration profile',
+                'verbose_name_plural': 'registration profiles',
+            },
+        ),
+    ]

--- a/registration/models.py
+++ b/registration/models.py
@@ -197,8 +197,8 @@ class RegistrationProfile(models.Model):
     """
     ACTIVATED = u"ALREADY_ACTIVATED"
 
-    user = models.ForeignKey(
-        settings.AUTH_USER_MODEL, unique=True, verbose_name=_('user'))
+    user = models.OneToOneField(
+        settings.AUTH_USER_MODEL, verbose_name=_('user'))
     activation_key = models.CharField(_('activation key'), max_length=40)
 
     objects = RegistrationManager()
@@ -287,4 +287,3 @@ class RegistrationProfile(models.Model):
                                    ctx_dict)
 
         self.user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL)
-


### PR DESCRIPTION
- Migrations to work with Django 1.8
- Also use OneToOneField as reconmended by Django